### PR TITLE
請求入力：契約済みの見積り一覧を表示する

### DIFF
--- a/src/pages/projPaymentInvoice/fieldComponents/EstimateCards.tsx
+++ b/src/pages/projPaymentInvoice/fieldComponents/EstimateCards.tsx
@@ -6,7 +6,7 @@ export const EstimateCards = ({
   projId: string
 }) => {
 
-  /* 工事情報から契約済みの見積もり情報を取り出す */
+  /* 工事情報から契約済みの見積もり情報を取り出す T163にて対応 */
   const contracts = [{
     estimateId: '1',
     amount: 'a',

--- a/src/pages/projPaymentInvoice/fieldComponents/EstimateCards.tsx
+++ b/src/pages/projPaymentInvoice/fieldComponents/EstimateCards.tsx
@@ -1,4 +1,26 @@
-import { Card, CardContent, Stack, Typography } from '@mui/material';
+import { Card, CardContent, Chip, CircularProgress, FormHelperText, Stack, Typography } from '@mui/material';
+import { isEmpty } from 'lodash';
+import { FormikLabeledCheckBox } from '../../../components/ui/checkboxes';
+import { useEstimatesByProjId } from '../../../hooksQuery/useEstimatesByProjId';
+
+const FormLabel = ({
+  label,
+  value,
+}: {
+  label: string,
+  value: string,
+}) => {
+  return (
+    <Stack direction={'row'} spacing={2}>
+      <Typography variant='caption'>
+        {label}
+      </Typography>
+      <Typography>
+        {value}
+      </Typography>
+    </Stack>
+  );
+};
 
 export const EstimateCards = ({
   projId,
@@ -6,38 +28,76 @@ export const EstimateCards = ({
   projId: string
 }) => {
 
-  /* 工事情報から契約済みの見積もり情報を取り出す T163にて対応 */
-  const contracts = [{
-    estimateId: '1',
-    amount: 'a',
-  }, {
-    estimateId: '2',
-    amount: 'b',
-  }, {
-    estimateId: '3',
-    amount: 'c',
-  }]; // ダミーデータ
+  const {
+    data,
+    error,
+    isFetching,
+  } = useEstimatesByProjId(projId);
 
-  /* 取り出した見積もり情報(複数)をカードで表示する */
+  const {
+    calculated,
+    records,
+  } = data || {};
+
+  const found = Boolean(records?.find(record => !isEmpty(record.envStatus.value)));
+
 
   return (
     <>
       <Typography variant='caption'>
-        契約一覧 ※要編集
+        契約一覧
       </Typography>
-      <Stack direction={'row'} spacing={2}>
-        {contracts.map((contract) => {
+      {isFetching && <CircularProgress />}
+      {!isFetching && <Stack direction={'row'} spacing={2}>
+        {!!records && !!calculated && records.map((record, idx) => {
+
+          if (!record.envStatus.value) return; // 未契約の情報は表示しない
+
           return (
-            <Card key={projId + contract.estimateId}>
+            <Card key={`${projId}_${record.$id.value}`}>
               <CardContent>
-                <Typography>
-                  {`見積もり情報：${contract.amount}`}
-                </Typography>
+                <Stack spacing={1} direction={'row'}>
+                  {!!record.estimateStatus.value &&
+                    <Chip
+                      size='small'
+                      color="primary"
+                      label={record.estimateStatus.value}
+                    />}
+                  <Chip
+                    size='small'
+                    color="success"
+                    label='契約'
+                  />
+                </Stack>
+                <FormLabel label='見積もり番号' value={record.$id.value} />
+                <FormLabel
+                  label='契約金額'
+                  value={Math.round(calculated[idx].totalAmountInclTax).toLocaleString() + '円'}
+                />
+                <FormLabel
+                  label='契約日'
+                  value={record.contractDate.value}
+                />
+                <FormikLabeledCheckBox
+                  label='請求に使用しない'
+                  name={`dummy${record.$id.value}`}
+                />
               </CardContent>
             </Card>
           );
         })}
-      </Stack>
+      </Stack>}
+      {!isFetching && !found && records && <Typography>
+        契約済みの見積もりがありません
+      </Typography>}
+      {!isFetching && !records && !calculated && !projId && <Typography>
+        工事が選択されていません
+      </Typography>}
+      {!!error && (
+        <FormHelperText error={true}>
+          {`エラーが発生しました。${error}`}
+        </FormHelperText>
+      )}
     </>
   );
 };

--- a/src/pages/projPaymentInvoice/form.ts
+++ b/src/pages/projPaymentInvoice/form.ts
@@ -18,7 +18,7 @@ export const initialValues = {
 
   /* 請求内容 */
   amountType: '', // 請求金の種別
-  billingAmount: '', // 請求残高
+  billingAmount: '', // 請求金額
   
   /* 入金予定日 */
   plannedPaymentDate: '',


### PR DESCRIPTION
**変更**

請求入力ページの、契約済み一覧の表示を正式に反映します。

**変更理由**

要件実装：[T163](https://trello.com/c/B9oGulLd)

**依存情報**

[PR133](https://github.com/Lorenzras/kokoas-monorepo/pull/133)のレビューを先にお願いします。