### PR TITLE
hookQueryに関わる関数のリファクタリング

### DIFF
--- a/src/api/kintone/config.ts
+++ b/src/api/kintone/config.ts
@@ -26,8 +26,15 @@ export enum APPIDS {
   employees = 34,
   custGroup = 185,
   custMemo = 181,
+
+  /** @deprecated Use projType instead */
   constructionType = 190,
+
+  /** @deprecated Use project instead */
   constructionDetails = 194,
+
+  projType = 190,
+  project = 194,
   projectEstimate = 202,
   paymentInvoice = 204,
 }

--- a/src/api/kintone/custgroups/GET.ts
+++ b/src/api/kintone/custgroups/GET.ts
@@ -9,6 +9,7 @@ export interface AdvancedSearchCustGroupParam {
   offset?: string,
 }
 
+/** @deprecated ファイル構成ルール変更によります。./getCustGroupById に変更してください */
 export const getCustGroup = (id: string) => {
   return KintoneRecord.getRecord({ app: APPIDS.custGroup, id })
     .then(resp => resp.record as unknown as CustomerGroupTypes.SavedData );

--- a/src/api/kintone/custgroups/getCustGroupById.ts
+++ b/src/api/kintone/custgroups/getCustGroupById.ts
@@ -1,0 +1,9 @@
+import { APPIDS, KintoneRecord } from '../config';
+
+export const getCustGroupById = (custGroupId: string) => {
+  return KintoneRecord.getRecord({
+    app: APPIDS.custGroup,
+    id: custGroupId,
+  }).then(({ record }) => record as unknown as CustomerGroupTypes.SavedData );
+
+};

--- a/src/api/kintone/projects/getProjById.ts
+++ b/src/api/kintone/projects/getProjById.ts
@@ -1,0 +1,8 @@
+import { APPIDS, KintoneRecord } from '../config';
+
+export const getProjById = (projId: string) => {
+  return KintoneRecord.getRecord({
+    app: APPIDS.project,
+    id: projId,
+  }).then(({ record }) => record as unknown as ProjectDetails.SavedData);
+};

--- a/src/hooksQuery/useCustGroupById.ts
+++ b/src/hooksQuery/useCustGroupById.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { APPIDS, KintoneRecord } from '../api/kintone';
+import { APPIDS } from '../api/kintone';
+import { getCustGroupById } from '../api/kintone/custgroups/getCustGroupById';
 
 /**
  * 顧客グループ番号で、顧客グループのデータを取得する。
@@ -9,12 +10,7 @@ import { APPIDS, KintoneRecord } from '../api/kintone';
 export const useCustGroupById = (custGroupId : string) => {
   return useQuery(
     [APPIDS.custGroup, custGroupId],
-    () => {
-      return KintoneRecord.getRecord({
-        app: APPIDS.custGroup,
-        id: custGroupId,
-      }).then(({ record }) => record as unknown as CustomerGroupTypes.SavedData );
-    },
+    () => getCustGroupById(custGroupId),
     {
       enabled: !!custGroupId,
     },

--- a/src/hooksQuery/useCustGroupById.ts
+++ b/src/hooksQuery/useCustGroupById.ts
@@ -4,8 +4,6 @@ import { getCustGroupById } from '../api/kintone/custgroups/getCustGroupById';
 
 /**
  * 顧客グループ番号で、顧客グループのデータを取得する。
- * @param custGroupId 顧客グループ番号
- * @returns {CustomerGroupTypes.SavedData} 顧客グループ番号データ
  */
 export const useCustGroupById = (custGroupId : string) => {
   return useQuery(

--- a/src/hooksQuery/useCustGroupByProjId.ts
+++ b/src/hooksQuery/useCustGroupByProjId.ts
@@ -6,8 +6,6 @@ import { useProjById } from './useProjById';
 
 /**
  * 工事番号で、顧客グループと工事データを取得する。
- * @param projId 工事番号
- * @returns 工事と顧客グループデータ
  */
 export const useCustGroupByProjId = (projId: string) => {
   const { data: projData } = useProjById(projId);

--- a/src/hooksQuery/useCustGroupByProjId.ts
+++ b/src/hooksQuery/useCustGroupByProjId.ts
@@ -16,7 +16,7 @@ export const useCustGroupByProjId = (projId: string) => {
   const { data: custGroupData } = useCustGroupById(custGroupId || '');
 
   return useQuery(
-    [APPIDS.constructionDetails, APPIDS.custGroup, projId],
+    [APPIDS.project, APPIDS.custGroup, projId],
     () => {
       return {
         custGroupData,

--- a/src/hooksQuery/useEstimateById.ts
+++ b/src/hooksQuery/useEstimateById.ts
@@ -5,8 +5,6 @@ import { getEstimatesById } from '../api/kintone/estimates/getEstimatesById';
 
 /**
  * 見積番号で取得する
- * @param projEstimateId 見積もり番号
- * @return
  */
 export const useEstimateById = (projEstimateId: string) => {
 

--- a/src/hooksQuery/useEstimatesByProjId.ts
+++ b/src/hooksQuery/useEstimatesByProjId.ts
@@ -4,8 +4,6 @@ import { getEstimatesByProjId } from '../api/kintone/estimates/getEstimatesByPro
 
 /**
  * 工事番号で見積リストを取得する
- * @param projId
- * @returns {Estimates.main.SavedData[]} 見積リスト
  */
 export const useEstimatesByProjId = (
   projId: string,

--- a/src/hooksQuery/useProjById.ts
+++ b/src/hooksQuery/useProjById.ts
@@ -1,5 +1,6 @@
-import { APPIDS, KintoneRecord } from '../api/kintone';
+import { APPIDS } from '../api/kintone';
 import { useQuery } from '@tanstack/react-query';
+import { getProjById } from '../api/kintone/projects/getProjById';
 
 /**
  * 工事番号で、工事のデータを取得する。
@@ -7,13 +8,8 @@ import { useQuery } from '@tanstack/react-query';
 export const useProjById = (projId: string) => {
 
   return useQuery(
-    [APPIDS.constructionDetails, projId],
-    () => {
-      return KintoneRecord.getRecord({
-        app: APPIDS.constructionDetails,
-        id: projId,
-      }).then(({ record }) => record as unknown as ProjectDetails.SavedData);
-    },
+    [APPIDS.project, projId],
+    () => getProjById(projId),
     {
       enabled: !!projId,
     },


### PR DESCRIPTION
早川さんのリファクタリング (ファイル構成の改善) 作業の続きです。

## 変更

-  react-queryの独自フックに処理を別のファイル・関数にする。
- 同じような関数をGET, PUT, POSTなどで整理していましたが、１関数＝１ファイルという構成に変更

## 変更理由

- react-queryの独自フックに処理を直接組むと、単体テストが難しいと気づきました。
- コード移動やTESTがより簡単になるし、コンフリクトの対策にもなります。

## 備考

- hooksQueryに実装してある関数だけカーバします。
- 一括リファクタリングが難しいので、既存のものをdeprecatedにして、リファクタリング作業をします。
もし、将来的タスクに関わるところにdeprecatedがあれば、その時修正を行います。


## 参考

https://levelup.gitconnected.com/advanced-code-organization-patterns-the-case-for-one-function-per-file-da68c15826e8